### PR TITLE
QPPSF-3608 Add Provider Id to measurement sets when parsing TSVs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+cd ./src/com/eviware/soapui && \
+# Compiling Groovy Files
+groovyc *.groovy && \
+mkdir ./src/ && \
+mv ./com/ ./src/ && \
+# Moving Java and their class files to be packaged
+cp -r ./report/ ./src/com/eviware/soapui/report && \
+cp -r ./reports/ ./src/com/eviware/soapui/reports && \
+cp -r ./tools/ ./src/com/eviware/soapui/tools && \
+cd ./src/ && \
+# Building JAR for SoapUI. To be placed in /Applications/SoapUI-5.4.0.app/Contents/java/app/lib/
+jar -cvf custom-report.jar . && \
+# Clean up
+mv custom-report.jar ../../../../../ && \
+cd .. && \
+rm -rf ./src/

--- a/src/com/eviware/soapui/ScenarioReader.groovy
+++ b/src/com/eviware/soapui/ScenarioReader.groovy
@@ -42,9 +42,13 @@ class ScenarioReader {
 // cfgSnippets -- A function for configuring all measurement templates to later be used in toMeasurementSets() and toMeasurements()
   public void cfgSnippets() {
     this.addXSnippet('MSET_TEMPLATE', ' {"programName": "mips","category":"${category}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","submissionMethod": "${sub_method}","measurements":[${MEASUREMENTS}]}')
+    this.addXSnippet('2018_QUALITY_MSET_TEMPLATE', ' {"programName": "mips","category":"${category}","submissionMethod": "${sub_method}","measurements":[${MEASUREMENTS}]}')
     this.addXSnippet('NONPROP_MEASURE_TPL', '{"measureId": "${measure_id}","value": {"isEndToEndReported": ${end_to_end},"numerator": ${numerator},"denominator": ${denominator},"denominatorException": ${denominator_exc},"numeratorExclusion":${numerator_exc}}}')
+    this.addXSnippet('2018_NONPROP_MEASURE_TPL', '{"measureId": "${measure_id}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","value": {"isEndToEndReported": ${end_to_end},"numerator": ${numerator},"denominator": ${denominator},"denominatorException": ${denominator_exc},"numeratorExclusion":${numerator_exc}}}')
     this.addXSnippet('SINGLE_MEASURE', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"performanceMet":${perf_met},"eligiblePopulationException":${perf_excep},"eligiblePopulationExclusion":${perf_exclu},"performanceNotMet":${perf_not_met},"eligiblePopulation":${pop_total}}}')
+    this.addXSnippet('2018_SINGLE_MEASURE', '{"measureId":"${measure_id}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}", "value":{"isEndToEndReported":${end_to_end},"performanceMet":${perf_met},"eligiblePopulationException":${perf_excep},"eligiblePopulationExclusion":${perf_exclu},"performanceNotMet":${perf_not_met},"eligiblePopulation":${pop_total}}}')
     this.addXSnippet('MULTI_MEASURE', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"strata":[${STRATUM}]}}')
+    this.addXSnippet('2018_MULTI_MEASURE', '{"measureId":"${measure_id}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","value":{"isEndToEndReported":${end_to_end},"strata":[${STRATUM}]}}')
     this.addXSnippet('STRATUM', '{"performanceMet":${perf_met},"eligiblePopulationException":${perf_excep},"eligiblePopulationExclusion":${perf_exclu},"performanceNotMet":${perf_not_met},"eligiblePopulation":${pop_total},"stratum":"${stratum}"}')
     this.addXSnippet('ACI_MEASURE_TEMPLATE', '{"measureId":"${measure_id}","value":${value}}')
     this.addXSnippet('ACI_ALT_MEASURE_TEMPLATE', '{"measureId":"${measure_id}","value":{"numerator":${value_numerator},"denominator":${value_denominator}}}')
@@ -52,13 +56,17 @@ class ScenarioReader {
     this.addXSnippet('ACR_Idx_COUNTS', '{"code":"${indexAdmissionCode}","count":${count}}')
     this.addXSnippet('ACR_Readd_COUNTS', '{"code":"${readmissionCode}","count":${count}}')
     this.addXSnippet('ACR_MEASURE', '{"measureId":"${measure_id}","value":{"score":${score},"details":{"numberOfIndexAdmissions":${numberOfIndexAdmissions},"numberOfReadmissions":${numberOfReadmissions},"indexReadmissionDiagnosisPairCounts":[${IDX_READD_PAIR_COUNTS}],"indexAdmissionCountByDiagnosis":[${idxAdminCodes}],"readmissionCountByDiagnosis":[${readdCodes}],"plannedReadmissions":${plannedReadmissions}}}}')
+    this.addXSnippet('2018_ACR_MEASURE', '{"measureId":"${measure_id}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","value":{"score":${score},"details":{"numberOfIndexAdmissions":${numberOfIndexAdmissions},"numberOfReadmissions":${numberOfReadmissions},"indexReadmissionDiagnosisPairCounts":[${IDX_READD_PAIR_COUNTS}],"indexAdmissionCountByDiagnosis":[${idxAdminCodes}],"readmissionCountByDiagnosis":[${readdCodes}],"plannedReadmissions":${plannedReadmissions}}}}')
     this.addXSnippet('CAHPS_MEASURE_TPL', '{"measureId":"${measure_id}","value":{"score":${score},"reliability":"${cahps_reliability}","mask":${cahps_mask},"isBelowMinimum":${cahps_isBelowMinimum}}}')
+    this.addXSnippet('2018_CAHPS_MEASURE_TPL', '{"measureId":"${measure_id}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","value":{"score":${score},"reliability":"${cahps_reliability}","mask":${cahps_mask},"isBelowMinimum":${cahps_isBelowMinimum}}}')
     this.addXSnippet('PROP_MEASURE_TPL', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"performanceMet":${perf_met},"eligiblePopulationException":${perf_excep},"eligiblePopulationExclusion":${perf_exclu},"performanceNotMet":${perf_not_met},"performanceRate":${performanceRate},"eligiblePopulation":${pop_total}}}')
+    this.addXSnippet('2018_PROP_MEASURE_TPL', '{"measureId":"${measure_id}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","value":{"isEndToEndReported":${end_to_end},"performanceMet":${perf_met},"eligiblePopulationException":${perf_excep},"eligiblePopulationExclusion":${perf_exclu},"performanceNotMet":${perf_not_met},"performanceRate":${performanceRate},"eligiblePopulation":${pop_total}}}')
     this.addXSnippet('PROP_MULTI_MEASURE_TPL', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"performanceRate":${performanceRate},"strata":[${STRATUM}]}}')
+    this.addXSnippet('2018_PROP_MULTI_MEASURE_TPL', '{"measureId":"${measure_id}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","value":{"isEndToEndReported":${end_to_end},"performanceRate":${performanceRate},"strata":[${STRATUM}]}}')
     this.addXSnippet('COST_MEASURE_TEMPLATE', '{"measureId":"${measure_id}","value":{"score":${score},"details":{"ratio":${ratio},"eligibleOccurrences":${eligibleOccurrences},"costPerOccurrence":${costPerOccurrence}}}}')
   }
 
-// ScenarioReader -- Class used to initialize all necessary files 
+// ScenarioReader -- Class used to initialize all necessary files
   public ScenarioReader(String folder, String inputFileName, String outputFileName) {
     this.cfgSnippets()
     this.inputFile = new File(folder, inputFileName);
@@ -108,7 +116,7 @@ class ScenarioReader {
 /* addXSnippet -- A function for creating snippets or templates. Primarily used to set templates for measurements or basic JSON structures for API calls.
 ** -- Note --
 ** In the newSnippet string, values wrapped in ${} are replaced by the corresponding PROP name either defined in code or the column name in the TSV.
-** 
+**
 ** @param name       :: String -- ex. "MEASUREMENT_TEMPLATE"
 ** @param newSnippet :: String -- ex. '{ "name": ${MEASURE_NAME}, "value": ${MEASURE_VALUE}}'
 */
@@ -155,6 +163,7 @@ class ScenarioReader {
     def measureList = [];
     list.each { s ->
       def measureCategory = s.data.get('category')
+      def perfYear = s.data.get('perf_year')
       if (s.data.get('mset_id') != msetConstraint) { return; }
       // Begin ACI Measurement Creation
       if (measureCategory == 'aci' || measureCategory == 'pi') {
@@ -188,7 +197,7 @@ class ScenarioReader {
             s.data.put('IDX_READD_PAIR_COUNTS', acrList.join(','))
             s.data.put('idxAdminCodes', indexAdmissionCodes.join(','))
             s.data.put('readdCodes', readmissionCodes.join(','))
-            measureList << s.eval(SNIPPETS['ACR_MEASURE'])
+            measureList << s.eval((perfYear == '2018') ? SNIPPETS['2018_ACR_MEASURE'] : SNIPPETS['ACR_MEASURE'])
           } else {
             // Stratum Measures
             def stratumList = [];
@@ -199,25 +208,25 @@ class ScenarioReader {
             s.data.put('STRATUM', stratumList.join(','))
             // Proportional Stratum Measures
             if (!this.isEmptyOrNull(s.data.get('performanceRate'))) {
-              measureList << s.eval(SNIPPETS['PROP_MULTI_MEASURE_TPL'])
+              measureList << s.eval((perfYear == '2018') ? SNIPPETS['2018_PROP_MULTI_MEASURE_TPL'] : SNIPPETS['PROP_MULTI_MEASURE_TPL'])
             // Stratum Measures
             } else {
-              measureList << s.eval(SNIPPETS['MULTI_MEASURE'])
+              measureList << s.eval((perfYear == '2018') ? SNIPPETS['2018_MULTI_MEASURE'] : SNIPPETS['MULTI_MEASURE'])
             }
           }
         } else {
           // CAHPS Measure
           if (!this.isEmptyOrNull(s.data.get('cahps_reliability')) && !this.isEmptyOrNull(s.data.get('cahps_mask')) && !this.isEmptyOrNull(s.data.get('cahps_isBelowMinimum'))) {
-            measureList << s.eval(SNIPPETS['CAHPS_MEASURE_TPL'])
+            measureList << s.eval((perfYear == '2018') ? SNIPPETS['2018_CAHPS_MEASURE_TPL'] : SNIPPETS['CAHPS_MEASURE_TPL'])
           // NonProportional Measure
           } else if (!this.isEmptyOrNull(s.data.get('end_to_end')) && !this.isEmptyOrNull(s.data.get('numerator')) && !this.isEmptyOrNull(s.data.get('denominator')) && !this.isEmptyOrNull(s.data.get('denominator_exc')) && !this.isEmptyOrNull(s.data.get('numerator_exc'))) {
-            measureList << s.eval(SNIPPETS['NONPROP_MEASURE_TPL'])
+            measureList << s.eval((perfYear == '2018') ? SNIPPETS['2018_NONPROP_MEASURE_TPL'] : SNIPPETS['NONPROP_MEASURE_TPL'])
           // Proportional Measure
           } else if (!this.isEmptyOrNull(s.data.get('performanceRate'))) {
-            measureList << s.eval(SNIPPETS['PROP_MEASURE_TPL'])
+            measureList << s.eval((perfYear == '2018') ? SNIPPETS['2018_PROP_MEASURE_TPL'] : SNIPPETS['PROP_MEASURE_TPL'])
           // Standard Single Measure
           } else {
-            measureList << s.eval(SNIPPETS['SINGLE_MEASURE'])
+            measureList << s.eval((perfYear == '2018') ? SNIPPETS['2018_SINGLE_MEASURE'] : SNIPPETS['SINGLE_MEASURE'])
           }
         }
       } else if (measureCategory == 'cost') {
@@ -234,9 +243,15 @@ class ScenarioReader {
   public String toMeasurementSets(List<Scenario> list) {
     def Set msetList = [];
     list.each { s ->
+      def measureCategory = s.data.get('category')
+      def perfYear = s.data.get('perf_year')
       def msetName = s.data.get('mset_id')
       s.data.put('MEASUREMENTS', '${MEASUREMENTS_' + msetName + '}' )
-      msetList << s.eval(SNIPPETS['MSET_TEMPLATE'])
+      if(perfYear == '2018' && measureCategory == 'quality') {
+        msetList << s.eval(SNIPPETS['2018_QUALITY_MSET_TEMPLATE'])
+      } else {
+        msetList << s.eval(SNIPPETS['MSET_TEMPLATE'])
+      }
     }
     return msetList.join(',');
   }
@@ -278,4 +293,3 @@ class ScenarioReader {
     copyScenarioProperties(this.propsStep, this.currentScenarioList)
   }
 }
-

--- a/src/com/eviware/soapui/ScenarioReader.groovy
+++ b/src/com/eviware/soapui/ScenarioReader.groovy
@@ -55,6 +55,7 @@ class ScenarioReader {
     this.addXSnippet('CAHPS_MEASURE_TPL', '{"measureId":"${measure_id}","value":{"score":${score},"reliability":"${cahps_reliability}","mask":${cahps_mask},"isBelowMinimum":${cahps_isBelowMinimum}}}')
     this.addXSnippet('PROP_MEASURE_TPL', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"performanceMet":${perf_met},"eligiblePopulationException":${perf_excep},"eligiblePopulationExclusion":${perf_exclu},"performanceNotMet":${perf_not_met},"performanceRate":${performanceRate},"eligiblePopulation":${pop_total}}}')
     this.addXSnippet('PROP_MULTI_MEASURE_TPL', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"performanceRate":${performanceRate},"strata":[${STRATUM}]}}')
+    this.addXSnippet('COST_MEASURE_TEMPLATE', '{"measureId":"${measure_id}","value":{"score":${score},"details":{"ratio":${ratio},"eligibleOccurrences":${eligibleOccurrences},"costPerOccurrence":${costPerOccurrence}}}}')
   }
 
 // ScenarioReader -- Class used to initialize all necessary files 
@@ -218,6 +219,10 @@ class ScenarioReader {
           } else {
             measureList << s.eval(SNIPPETS['SINGLE_MEASURE'])
           }
+        }
+      } else if (measureCategory == 'cost') {
+        if (!this.isEmptyOrNull(s.data.get('score')) && !this.isEmptyOrNull(s.data.get('ratio')) && !this.isEmptyOrNull(s.data.get('eligibleOccurrences')) && !this.isEmptyOrNull(s.data.get('costPerOccurrence'))) {
+          measureList << s.eval(SNIPPETS['COST_MEASURE_TEMPLATE'])
         }
       }
       // End Quality Measurement Creation

--- a/src/com/eviware/soapui/ScenarioReader.groovy
+++ b/src/com/eviware/soapui/ScenarioReader.groovy
@@ -1,211 +1,275 @@
 package com.eviware.soapui
 
+/* ScenarioReader
+** :: Notes ::
+** ScenarioReader is a class for processing .TSV files within the SoapUI framework and coverting each row or group of rows into JSON to be saved as properties in the "prop" file of the corresponding scenario.
+**
+** There are two primary workflows used by SoapUI. Initialization, Setting Props, Documenting Results.
+** -- Initialization --
+** ScenarioReader -> toScenario() -> addScenario()
+** -- Setting Props --
+** next() -> copyScenarioProperties() -> toMeasurementSets() -> toMeasurements()
+** -- Documenting Results --
+** writeScenarioStatus()
+**
+** -- Prereq --
+** Needs access to the Scenario class located ./Scenario.groovy.
+**
+** ScenarioReader :: Class
+** @param folder         -- Absolute path of the ScenarioReader projectt
+** @param inputFileName  -- Path to input file for data processing
+** @param outputFileName -- Path to output file for saving results
+*/
+
 class ScenarioReader {
-    static TEMPLATE_ENGINE = new groovy.text.SimpleTemplateEngine()
-    static SNIPPETS = [:]
+  static TEMPLATE_ENGINE = new groovy.text.SimpleTemplateEngine()
+  static SNIPPETS = [:]
 
-    private File inputFile;
-    private File outputFile;
-    private BufferedReader reader;
-    private BufferedWriter writer;
-    private String[] header;
-    private String line;
-    private scenarioId = 'scenario_id';
-    private measureId = 'measure_id';
-    private msetId = 'mset_id';
-    public Map<String, List<Scenario>> scenarioMap = [:];
-    public Iterator it;
-    def propsStep;
-    List<Scenario> currentScenarioList;
+  private File inputFile;
+  private File outputFile;
+  private BufferedReader reader;
+  private BufferedWriter writer;
+  private String[] header;
+  private String line;
+  private scenarioId = 'scenario_id';
+  private measureId = 'measure_id';
+  private msetId = 'mset_id';
+  public Map<String, List<Scenario>> scenarioMap = [:];
+  public Iterator it;
+  def propsStep;
+  List<Scenario> currentScenarioList;
 
-    public void cfgSnippets() {
-    	   this.addXSnippet('MSET_TEMPLATE', ' {"programName": "mips","category":"${category}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","submissionMethod": "${sub_method}","measurements":[${MEASUREMENTS}]}')
-    	   this.addXSnippet('NONPROP_MEASURE_TPL', '{"measureId": "${measure_id}","value": {"isEndToEndReported": ${end_to_end},"numerator": ${numerator},"denominator": ${denominator},"denominatorException": ${denominator_exc},"numeratorExclusion":${numerator_exc}}}')
-    	   this.addXSnippet('SINGLE_MEASURE', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"performanceMet":${perf_met},"eligiblePopulationException":${perf_excep},"eligiblePopulationExclusion":${perf_exclu},"performanceNotMet":${perf_not_met},"eligiblePopulation":${pop_total}}}')
-    	   this.addXSnippet('MULTI_MEASURE', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"strata":[${STRATUM}]}}')
-    	   this.addXSnippet('STRATUM', '{"performanceMet":${perf_met},"eligiblePopulationException":${perf_excep},"eligiblePopulationExclusion":${perf_exclu},"performanceNotMet":${perf_not_met},"eligiblePopulation":${pop_total},"stratum":"${stratum}"}')
-    	   this.addXSnippet('ACI_MEASURE_TEMPLATE', '{"measureId":"${measure_id}","value":${value}}')
-    	   this.addXSnippet('ACI_ALT_MEASURE_TEMPLATE', '{"measureId":"${measure_id}","value":{"numerator":${value_numerator},"denominator":${value_denominator}}}')
-    	   this.addXSnippet('IDX_READD_PAIR_COUNTS', '{"indexAdmissionCode":"${indexAdmissionCode}","readmissionCode":"${readmissionCode}","count":${count}}')
-    	   this.addXSnippet('ACR_Idx_COUNTS', '{"code":"${indexAdmissionCode}","count":${count}}')
-    	   this.addXSnippet('ACR_Readd_COUNTS', '{"code":"${readmissionCode}","count":${count}}')
-    	   this.addXSnippet('ACR_MEASURE', '{"measureId":"${measure_id}","value":{"score":${score},"details":{"numberOfIndexAdmissions":${numberOfIndexAdmissions},"numberOfReadmissions":${numberOfReadmissions},"indexReadmissionDiagnosisPairCounts":[${IDX_READD_PAIR_COUNTS}],"indexAdmissionCountByDiagnosis":[${idxAdminCodes}],"readmissionCountByDiagnosis":[${readdCodes}],"plannedReadmissions":${plannedReadmissions}}}}')
-    	   this.addXSnippet('CAHPS_MEASURE_TPL', '{"measureId":"${measure_id}","value":{"score":${score},"reliability":"${cahps_reliability}","mask":${cahps_mask},"isBelowMinimum":${cahps_isBelowMinimum}}}')
-         this.addXSnippet('PROP_MEASURE_TPL', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"performanceMet":${perf_met},"eligiblePopulationException":${perf_excep},"eligiblePopulationExclusion":${perf_exclu},"performanceNotMet":${perf_not_met},"performanceRate":${performanceRate},"eligiblePopulation":${pop_total}}}')
-         this.addXSnippet('PROP_MULTI_MEASURE_TPL', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"performanceRate":${performanceRate},"strata":[${STRATUM}]}}')
+// cfgSnippets -- A function for configuring all measurement templates to later be used in toMeasurementSets() and toMeasurements()
+  public void cfgSnippets() {
+    this.addXSnippet('MSET_TEMPLATE', ' {"programName": "mips","category":"${category}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","submissionMethod": "${sub_method}","measurements":[${MEASUREMENTS}]}')
+    this.addXSnippet('NONPROP_MEASURE_TPL', '{"measureId": "${measure_id}","value": {"isEndToEndReported": ${end_to_end},"numerator": ${numerator},"denominator": ${denominator},"denominatorException": ${denominator_exc},"numeratorExclusion":${numerator_exc}}}')
+    this.addXSnippet('SINGLE_MEASURE', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"performanceMet":${perf_met},"eligiblePopulationException":${perf_excep},"eligiblePopulationExclusion":${perf_exclu},"performanceNotMet":${perf_not_met},"eligiblePopulation":${pop_total}}}')
+    this.addXSnippet('MULTI_MEASURE', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"strata":[${STRATUM}]}}')
+    this.addXSnippet('STRATUM', '{"performanceMet":${perf_met},"eligiblePopulationException":${perf_excep},"eligiblePopulationExclusion":${perf_exclu},"performanceNotMet":${perf_not_met},"eligiblePopulation":${pop_total},"stratum":"${stratum}"}')
+    this.addXSnippet('ACI_MEASURE_TEMPLATE', '{"measureId":"${measure_id}","value":${value}}')
+    this.addXSnippet('ACI_ALT_MEASURE_TEMPLATE', '{"measureId":"${measure_id}","value":{"numerator":${value_numerator},"denominator":${value_denominator}}}')
+    this.addXSnippet('IDX_READD_PAIR_COUNTS', '{"indexAdmissionCode":"${indexAdmissionCode}","readmissionCode":"${readmissionCode}","count":${count}}')
+    this.addXSnippet('ACR_Idx_COUNTS', '{"code":"${indexAdmissionCode}","count":${count}}')
+    this.addXSnippet('ACR_Readd_COUNTS', '{"code":"${readmissionCode}","count":${count}}')
+    this.addXSnippet('ACR_MEASURE', '{"measureId":"${measure_id}","value":{"score":${score},"details":{"numberOfIndexAdmissions":${numberOfIndexAdmissions},"numberOfReadmissions":${numberOfReadmissions},"indexReadmissionDiagnosisPairCounts":[${IDX_READD_PAIR_COUNTS}],"indexAdmissionCountByDiagnosis":[${idxAdminCodes}],"readmissionCountByDiagnosis":[${readdCodes}],"plannedReadmissions":${plannedReadmissions}}}}')
+    this.addXSnippet('CAHPS_MEASURE_TPL', '{"measureId":"${measure_id}","value":{"score":${score},"reliability":"${cahps_reliability}","mask":${cahps_mask},"isBelowMinimum":${cahps_isBelowMinimum}}}')
+    this.addXSnippet('PROP_MEASURE_TPL', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"performanceMet":${perf_met},"eligiblePopulationException":${perf_excep},"eligiblePopulationExclusion":${perf_exclu},"performanceNotMet":${perf_not_met},"performanceRate":${performanceRate},"eligiblePopulation":${pop_total}}}')
+    this.addXSnippet('PROP_MULTI_MEASURE_TPL', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"performanceRate":${performanceRate},"strata":[${STRATUM}]}}')
+  }
+
+// ScenarioReader -- Class used to initialize all necessary files 
+  public ScenarioReader(String folder, String inputFileName, String outputFileName) {
+    this.cfgSnippets()
+    this.inputFile = new File(folder, inputFileName);
+    this.outputFile = new File(folder, outputFileName);
+    inputFile.eachLine {line, i ->
+      println(line)
+      if (i == 1) {
+        // First line of the TSV is the columns. We're converting this into an array to later be turned into Prop keys.
+        this.header = line.split("\t");
+      } else {
+        // Converting TSV row into a Scenario class.
+        def s = toScenario(line);
+        // Add Scenario classes to scenarioMap variable. Assigns Scenarios to the Scenario.children array if there are duplicate MeasurementIDs in the case of Stratum
+        this.addScenario(s);
+      }
     }
+    this.outputFile.delete();
+    this.outputFile << "test_status\t${this.header.join('\t')}\n"
+    this.it = this.scenarioMap.iterator();
+  }
 
-    public ScenarioReader(String folder, String inputFileName, String outputFileName) {
-    	  this.cfgSnippets()
-        this.inputFile = new File(folder, inputFileName);
-        this.outputFile = new File(folder, outputFileName);
-        inputFile.eachLine {line, i ->
-            println(line)
-            if (i == 1) {
-                this.header = line.split("\t");
-            } else {
-                def s = toScenario(line);
-                this.addScenario(s);
-            }
+// isEmptyOrNull :: a -> Bool
+  public boolean isEmptyOrNull(x) {
+    return (x == '' || x == null)
+  }
+
+// setPropsStep -- Function for defining SoapUI props within the class to later be manipulated and read by toMeasurementSets() and toMeasurements()
+  public void setPropsStep(def props) {
+    this.propsStep = props;
+  }
+
+// addSinglePerformanceMeasureSnippet -- Deprecated legacy function since replaced by addXSnippet() & cfgSnippets()
+  public void addSinglePerformanceMeasureSnippet(String measureSnippet){
+    SNIPPETS.put("SINGLE_MEASURE", TEMPLATE_ENGINE.createTemplate(measureSnippet));
+  }
+// addMultiPerformanceMeasureSnippet -- Deprecated legacy function since replaced by addXSnippet() & cfgSnippets()
+  public void addMultiPerformanceMeasureSnippet(String measureSnippet, String stratumSnippet) {
+    SNIPPETS.put('MULTI_MEASURE', TEMPLATE_ENGINE.createTemplate(measureSnippet))
+    SNIPPETS.put('STRATUM', TEMPLATE_ENGINE.createTemplate(stratumSnippet));
+  }
+
+// addMeasurementSetSnippet -- Deprecated legacy function since replaced by addXSnippet() & cfgSnippets()
+  public void addMeasurementSetSnippet(String msetSnippet) {
+    SNIPPETS.put('MSET_TEMPLATE', TEMPLATE_ENGINE.createTemplate(msetSnippet));
+  }
+
+/* addXSnippet -- A function for creating snippets or templates. Primarily used to set templates for measurements or basic JSON structures for API calls.
+** -- Note --
+** In the newSnippet string, values wrapped in ${} are replaced by the corresponding PROP name either defined in code or the column name in the TSV.
+** 
+** @param name       :: String -- ex. "MEASUREMENT_TEMPLATE"
+** @param newSnippet :: String -- ex. '{ "name": ${MEASURE_NAME}, "value": ${MEASURE_VALUE}}'
+*/
+  public void addXSnippet(String name, String newSnippet) {
+    SNIPPETS.put(name, TEMPLATE_ENGINE.createTemplate(newSnippet));
+  }
+
+// addScenario -- Add Scenario classes to scenarioMap variable. Assigns Scenarios to the Scenario.children array if there are duplicate MeasurementIDs in the case of Stratum
+  private void addScenario(Scenario s) {
+    if (scenarioMap.containsKey(s.scenarioId)) {
+      List<Scenario> scenarios = scenarioMap[s.scenarioId];
+      def last = scenarios.last();
+      if (last != null && last.getData().get(measureId).equals(s.getData().get(measureId))) {
+        last.addChildScenario(s);
+      } else {
+        scenarios << s;
+      }
+    } else {
+      scenarioMap.put(s.scenarioId, [s]);
+    }
+  }
+
+// getHeader :: [ String ]
+  public String[] getHeader() {
+    this.header;
+  }
+
+// Convert TSV row into Scenario class and groups them based on the `scenario_id` column
+  private Scenario toScenario(String line) {
+    String[] parts = line.split("\t");
+    def data = [:]
+    getHeader().eachWithIndex { k, i ->
+      data[k] = parts.length > i ? parts[i]?.trim() : null;
+    }
+    return new Scenario(this.header, data[scenarioId], data);
+  }
+
+/* toMeasurements -- Receives an array of Scenarios and the value under `mset_id` to set Props specific for generating measurements in the proper measurementSet in the Submissions Obj for `score-preview`
+**
+** @param list           :: [Scenario]
+** @param msetConstraint :: String
+*/
+  public String toMeasurements(List<Scenario> list, String msetConstraint) {
+    def measureList = [];
+    list.each { s ->
+      def measureCategory = s.data.get('category')
+      if (s.data.get('mset_id') != msetConstraint) { return; }
+      // Begin ACI Measurement Creation
+      if (measureCategory == 'aci') {
+        if (s.data.get('value') != '') {
+          measureList << s.eval(SNIPPETS['ACI_MEASURE_TEMPLATE'])
+        } else if (s.data.get('value_numerator') != '' && s.data.get('value_denominator') != '') {
+          measureList << s.eval(SNIPPETS['ACI_ALT_MEASURE_TEMPLATE'])
         }
-        this.outputFile.delete();
-        this.outputFile << "test_status\t${this.header.join('\t')}\n"
-        this.it = this.scenarioMap.iterator();
-    }
-
-    public boolean isEmptyOrNull(x) {
-        return (x == '' || x == null)
-    }
-
-    public void setPropsStep(def props) {
-        this.propsStep = props;
-    }
-
-    public void addSinglePerformanceMeasureSnippet(String measureSnippet){
-        SNIPPETS.put("SINGLE_MEASURE", TEMPLATE_ENGINE.createTemplate(measureSnippet));
-    }
-    public void addMultiPerformanceMeasureSnippet(String measureSnippet, String stratumSnippet) {
-        SNIPPETS.put('MULTI_MEASURE', TEMPLATE_ENGINE.createTemplate(measureSnippet))
-        SNIPPETS.put('STRATUM', TEMPLATE_ENGINE.createTemplate(stratumSnippet));
-    }
-
-    public void addMeasurementSetSnippet(String msetSnippet) {
-    	   SNIPPETS.put('MSET_TEMPLATE', TEMPLATE_ENGINE.createTemplate(msetSnippet));
-    }
-
-    public void addXSnippet(String name, String newSnippet) {
-        SNIPPETS.put(name, TEMPLATE_ENGINE.createTemplate(newSnippet));
-    }
-
-    private void addScenario(Scenario s) {
-        if (scenarioMap.containsKey(s.scenarioId)) {
-            List<Scenario> scenarios = scenarioMap[s.scenarioId];
-            def last = scenarios.last();
-            if (last != null && last.getData().get(measureId).equals(s.getData().get(measureId))) {
-                last.addChildScenario(s);
-            } else {
-                scenarios << s;
+      // End ACI Measurement Creation
+      // Begin IA Measurement Creation
+      } else if (measureCategory == 'ia') {
+        if (!this.isEmptyOrNull(s.data.get('value'))) {
+          measureList << s.eval(SNIPPETS['ACI_MEASURE_TEMPLATE'])
+        } else if (!this.isEmptyOrNull(s.data.get('value_numerator')) && !this.isEmptyOrNull(s.data.get('value_denominator'))) {
+          measureList << s.eval(SNIPPETS['ACI_ALT_MEASURE_TEMPLATE'])
+        }
+      // End IA Measurement Creation
+      // Begin Quality Measurement Creation
+      } else if (measureCategory == 'quality') {
+        if(s.children.size() > 0) {
+          // ACR Measures
+          if (!this.isEmptyOrNull(s.data.get('indexAdmissionCode')) && !this.isEmptyOrNull(s.data.get('readmissionCode')) && !this.isEmptyOrNull(s.data.get('score'))) {
+            def Set acrList = [];
+            def Set indexAdmissionCodes = [];
+            def Set readmissionCodes = [];
+            s.children.each { c->
+              acrList << s.eval(SNIPPETS['IDX_READD_PAIR_COUNTS']);
+              indexAdmissionCodes << s.eval(SNIPPETS['ACR_Idx_COUNTS']);
+              readmissionCodes << s.eval(SNIPPETS['ACR_Readd_COUNTS']);
             }
+            s.data.put('IDX_READD_PAIR_COUNTS', acrList.join(','))
+            s.data.put('idxAdminCodes', indexAdmissionCodes.join(','))
+            s.data.put('readdCodes', readmissionCodes.join(','))
+            measureList << s.eval(SNIPPETS['ACR_MEASURE'])
+          } else {
+            // Stratum Measures
+            def stratumList = [];
+            stratumList << s.eval(SNIPPETS['STRATUM'])
+            s.children.each { c->
+              stratumList << c.eval(SNIPPETS['STRATUM'])
+            }
+            s.data.put('STRATUM', stratumList.join(','))
+            // Proportional Stratum Measures
+            if (!this.isEmptyOrNull(s.data.get('performanceRate'))) {
+              measureList << s.eval(SNIPPETS['PROP_MULTI_MEASURE_TPL'])
+            // Stratum Measures
+            } else {
+              measureList << s.eval(SNIPPETS['MULTI_MEASURE'])
+            }
+          }
         } else {
-            scenarioMap.put(s.scenarioId, [s]);
+          // CAHPS Measure
+          if (!this.isEmptyOrNull(s.data.get('cahps_reliability')) && !this.isEmptyOrNull(s.data.get('cahps_mask')) && !this.isEmptyOrNull(s.data.get('cahps_isBelowMinimum'))) {
+            measureList << s.eval(SNIPPETS['CAHPS_MEASURE_TPL'])
+          // NonProportional Measure
+          } else if (!this.isEmptyOrNull(s.data.get('end_to_end')) && !this.isEmptyOrNull(s.data.get('numerator')) && !this.isEmptyOrNull(s.data.get('denominator')) && !this.isEmptyOrNull(s.data.get('denominator_exc')) && !this.isEmptyOrNull(s.data.get('numerator_exc'))) {
+            measureList << s.eval(SNIPPETS['NONPROP_MEASURE_TPL'])
+          // Proportional Measure
+          } else if (!this.isEmptyOrNull(s.data.get('performanceRate'))) {
+            measureList << s.eval(SNIPPETS['PROP_MEASURE_TPL'])
+          // Standard Single Measure
+          } else {
+            measureList << s.eval(SNIPPETS['SINGLE_MEASURE'])
+          }
         }
+      }
+      // End Quality Measurement Creation
     }
+    return measureList.join(',');
+  }
 
-    public String[] getHeader() {
-       this.header;
+// toMeasurementSets -- Responsible for creating Props for multiple measurementSets defined by the `mset_id` column.
+  public String toMeasurementSets(List<Scenario> list) {
+    def Set msetList = [];
+    list.each { s ->
+      def msetName = s.data.get('mset_id')
+      s.data.put('MEASUREMENTS', '${MEASUREMENTS_' + msetName + '}' )
+      msetList << s.eval(SNIPPETS['MSET_TEMPLATE'])
     }
+    return msetList.join(',');
+  }
 
-    private Scenario toScenario(String line) {
-        String[] parts = line.split("\t");
-        def data = [:]
-        getHeader().eachWithIndex { k, i ->
-           data[k] = parts.length > i ? parts[i]?.trim() : null;
-        }
-        return new Scenario(this.header, data[scenarioId], data);
+// copyScenarioProperties -- Responsible for creating and updating all Props in the `prop` test step.
+  public String copyScenarioProperties(def propsStep, List<Scenario> scenarios) {
+    if (scenarios.size() > 0) {
+      def last = scenarios.last();
+      last.getProperties().each {k,v ->
+        propsStep.setPropertyValue(k, v);
+      }
+      propsStep.setPropertyValue('MSETS', this.toMeasurementSets(scenarios))
+
+      def Set mSetsMeasurementProps = [];
+      scenarios.each { s ->
+        mSetsMeasurementProps << ['MEASUREMENTS_' + s.data.get('mset_id'), s.data.get('mset_id')]
+      }
+      mSetsMeasurementProps.each { measurementProp ->
+        propsStep.setPropertyValue(measurementProp[0], this.toMeasurements(scenarios, measurementProp[1]))
+      }
     }
+  }
 
-    public String toMeasurements(List<Scenario> list, String msetConstraint) {
-        def measureList = [];
-        list.each { s ->
-        	  def measureCategory = s.data.get('category')
-        	  if (s.data.get('mset_id') != msetConstraint) { return; }
-        	  if (measureCategory == 'aci') {
-        	  	if (s.data.get('value') != '') {
-        	  		measureList << s.eval(SNIPPETS['ACI_MEASURE_TEMPLATE'])
-        	  	} else if (s.data.get('value_numerator') != '' && s.data.get('value_denominator') != '') {
-        	  		measureList << s.eval(SNIPPETS['ACI_ALT_MEASURE_TEMPLATE'])
-        	  	}
-        	  } else if (measureCategory == 'ia') {
-      	  	if (!this.isEmptyOrNull(s.data.get('value'))) {
-        	  		measureList << s.eval(SNIPPETS['ACI_MEASURE_TEMPLATE'])
-        	  	} else if (!this.isEmptyOrNull(s.data.get('value_numerator')) && !this.isEmptyOrNull(s.data.get('value_denominator'))) {
-        	  		measureList << s.eval(SNIPPETS['ACI_ALT_MEASURE_TEMPLATE'])
-        	  	}
-        	  } else if (measureCategory == 'quality') {
-        	      if(s.children.size() > 0) {
-        	      	if (!this.isEmptyOrNull(s.data.get('indexAdmissionCode')) && !this.isEmptyOrNull(s.data.get('readmissionCode')) && !this.isEmptyOrNull(s.data.get('score'))) {
-        	      		def Set acrList = [];
-        	      		def Set indexAdmissionCodes = [];
-        	      		def Set readmissionCodes = [];
-        	      		s.children.each { c->
-        	      			acrList << s.eval(SNIPPETS['IDX_READD_PAIR_COUNTS']);
-        	      			indexAdmissionCodes << s.eval(SNIPPETS['ACR_Idx_COUNTS']);
-        	      			readmissionCodes << s.eval(SNIPPETS['ACR_Readd_COUNTS']);
-        	      		}
-        	      		s.data.put('IDX_READD_PAIR_COUNTS', acrList.join(','))
-        	      		s.data.put('idxAdminCodes', indexAdmissionCodes.join(','))
-        	      		s.data.put('readdCodes', readmissionCodes.join(','))
-        	      		measureList << s.eval(SNIPPETS['ACR_MEASURE'])
-        	      	} else {
-                		def stratumList = [];
-                		stratumList << s.eval(SNIPPETS['STRATUM'])
-                		s.children.each { c->
-                	 	   stratumList << c.eval(SNIPPETS['STRATUM'])
-                		}
-               		 s.data.put('STRATUM', stratumList.join(','))
-                    if (!this.isEmptyOrNull(s.data.get('performanceRate'))) {
-                      measureList << s.eval(SNIPPETS['PROP_MULTI_MEASURE_TPL'])
-                    } else {
-                      measureList << s.eval(SNIPPETS['MULTI_MEASURE'])
-                    }
-        	      	}
-           	 } else {
-           	 	if (!this.isEmptyOrNull(s.data.get('cahps_reliability')) && !this.isEmptyOrNull(s.data.get('cahps_mask')) && !this.isEmptyOrNull(s.data.get('cahps_isBelowMinimum'))) {
-        	      		measureList << s.eval(SNIPPETS['CAHPS_MEASURE_TPL'])
-        	      	} else if (!this.isEmptyOrNull(s.data.get('end_to_end')) && !this.isEmptyOrNull(s.data.get('numerator')) && !this.isEmptyOrNull(s.data.get('denominator')) && !this.isEmptyOrNull(s.data.get('denominator_exc')) && !this.isEmptyOrNull(s.data.get('numerator_exc'))) {
-        	      		measureList << s.eval(SNIPPETS['NONPROP_MEASURE_TPL'])
-        	      	} else if (!this.isEmptyOrNull(s.data.get('performanceRate'))) {
-                    measureList << s.eval(SNIPPETS['PROP_MEASURE_TPL'])
-        	      	} else {
-              	 		measureList << s.eval(SNIPPETS['SINGLE_MEASURE'])
-        	      	}
-            	 }
-        	  }
-        }
-        return measureList.join(',');
+// writeScenarioStatus -- Writes results of test scenarios to the assigned output file.
+  public void writeScenarioStatus(String status, List<Scenario> scenarios) {
+    scenarios.each {s ->
+      outputFile << s.toLine(status)
     }
+  }
 
-    public String toMeasurementSets(List<Scenario> list) {
-    	def Set msetList = [];
-    	list.each { s ->
-		def msetName = s.data.get('mset_id')
-		s.data.put('MEASUREMENTS', '${MEASUREMENTS_' + msetName + '}' )
-		msetList << s.eval(SNIPPETS['MSET_TEMPLATE'])
-    	}
-    	return msetList.join(',');
-    }
+// Checks iterator defined in ScenarioReader to see if the end of the TSV has been met.
+  public boolean hasNext() {
+    this.it.hasNext();
+  }
 
-    public String copyScenarioProperties(def propsStep, List<Scenario> scenarios) {
-        if (scenarios.size() > 0) {
-            def last = scenarios.last();
-            last.getProperties().each {k,v ->
-                propsStep.setPropertyValue(k, v);
-            }
-            propsStep.setPropertyValue('MSETS', this.toMeasurementSets(scenarios))
-
-            def Set mSetsMeasurementProps = [];
-            scenarios.each { s ->
-            	mSetsMeasurementProps << ['MEASUREMENTS_' + s.data.get('mset_id'), s.data.get('mset_id')]
-            }
-            mSetsMeasurementProps.each { measurementProp ->
-            	propsStep.setPropertyValue(measurementProp[0], this.toMeasurements(scenarios, measurementProp[1]))
-            }
-            
-        }
-    }
-
-    public void writeScenarioStatus(String status, List<Scenario> scenarios) {
-        scenarios.each {s ->
-            outputFile << s.toLine(status)
-        }
-    }
-
-    public boolean hasNext() {
-        this.it.hasNext();
-    }
-
-    public void next() {
-        this.currentScenarioList = this.it.next().value;
-        copyScenarioProperties(this.propsStep, this.currentScenarioList)
-    }
+// Prepares next set of scenarios grouped by `scenario_id`, configures props, and sets the stage for the test steps to be run again.
+  public void next() {
+    this.currentScenarioList = this.it.next().value;
+    copyScenarioProperties(this.propsStep, this.currentScenarioList)
+  }
 }

--- a/src/com/eviware/soapui/ScenarioReader.groovy
+++ b/src/com/eviware/soapui/ScenarioReader.groovy
@@ -157,7 +157,7 @@ class ScenarioReader {
       def measureCategory = s.data.get('category')
       if (s.data.get('mset_id') != msetConstraint) { return; }
       // Begin ACI Measurement Creation
-      if (measureCategory == 'aci') {
+      if (measureCategory == 'aci' || measureCategory == 'pi') {
         if (s.data.get('value') != '') {
           measureList << s.eval(SNIPPETS['ACI_MEASURE_TEMPLATE'])
         } else if (s.data.get('value_numerator') != '' && s.data.get('value_denominator') != '') {
@@ -278,3 +278,4 @@ class ScenarioReader {
     copyScenarioProperties(this.propsStep, this.currentScenarioList)
   }
 }
+

--- a/src/com/eviware/soapui/ScenarioReader.groovy
+++ b/src/com/eviware/soapui/ScenarioReader.groovy
@@ -41,8 +41,8 @@ class ScenarioReader {
 
 // cfgSnippets -- A function for configuring all measurement templates to later be used in toMeasurementSets() and toMeasurements()
   public void cfgSnippets() {
-    this.addXSnippet('MSET_TEMPLATE', ' {"programName": "mips","category":"${category}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","submissionMethod": "${sub_method}","measurements":[${MEASUREMENTS}]}')
-    this.addXSnippet('2018_QUALITY_MSET_TEMPLATE', ' {"programName": "mips","category":"${category}","submissionMethod": "${sub_method}","measurements":[${MEASUREMENTS}]}')
+    this.addXSnippet('MSET_TEMPLATE', ' {"programName": "mips","providerId":"${provider_id}","category":"${category}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","submissionMethod": "${sub_method}","measurements":[${MEASUREMENTS}]}')
+    this.addXSnippet('2018_QUALITY_MSET_TEMPLATE', ' {"programName": "mips","providerId":"${provider_id}","category":"${category}","submissionMethod": "${sub_method}","measurements":[${MEASUREMENTS}]}')
     this.addXSnippet('NONPROP_MEASURE_TPL', '{"measureId": "${measure_id}","value": {"isEndToEndReported": ${end_to_end},"numerator": ${numerator},"denominator": ${denominator},"denominatorException": ${denominator_exc},"numeratorExclusion":${numerator_exc}}}')
     this.addXSnippet('2018_NONPROP_MEASURE_TPL', '{"measureId": "${measure_id}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","value": {"isEndToEndReported": ${end_to_end},"numerator": ${numerator},"denominator": ${denominator},"denominatorException": ${denominator_exc},"numeratorExclusion":${numerator_exc}}}')
     this.addXSnippet('SINGLE_MEASURE', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"performanceMet":${perf_met},"eligiblePopulationException":${perf_excep},"eligiblePopulationExclusion":${perf_exclu},"performanceNotMet":${perf_not_met},"eligiblePopulation":${pop_total}}}')


### PR DESCRIPTION
Add Provider Id to measurement sets when parsing TSVs

---

### Summary

Add Provider Id to measurement sets when parsing TSVs

### Associated JIRA Tickets

* Tickets from https://jira.cms.gov/secure/RapidBoard.jspa?rapidView=1567&projectKey=QPPSF
* https://jira.cms.gov/browse/QPPSF-3608

### Reviewers

Comma separated list of people
@rockykitamura @kyleapfel @bijujoseph
